### PR TITLE
Fix LightClient interface

### DIFF
--- a/modules/handler/src/light_client/init_client.rs
+++ b/modules/handler/src/light_client/init_client.rs
@@ -3,7 +3,7 @@ use commitments::prover::prove_update_client_commitment;
 use context::Context;
 use enclave_commands::{InitClientInput, InitClientResult, LightClientResult};
 use lcp_types::Any;
-use light_client::{LightClientKeeper, LightClientReader, LightClientSource};
+use light_client::{ClientKeeper, ClientReader, LightClientSource};
 use store::KVStore;
 
 pub fn init_client<'l, S: KVStore, L: LightClientSource<'l>>(

--- a/modules/handler/src/light_client/registry.rs
+++ b/modules/handler/src/light_client/registry.rs
@@ -1,7 +1,7 @@
 use crate::light_client::LightClientHandlerError as Error;
 use context::Context;
 use ibc::core::ics24_host::identifier::ClientId;
-use light_client::{LightClient, LightClientError, LightClientReader, LightClientSource};
+use light_client::{ClientReader, LightClient, LightClientError, LightClientSource};
 use std::boxed::Box;
 use store::KVStore;
 

--- a/modules/handler/src/light_client/update_client.rs
+++ b/modules/handler/src/light_client/update_client.rs
@@ -3,7 +3,7 @@ use crate::light_client::LightClientHandlerError as Error;
 use commitments::prover::prove_update_client_commitment;
 use context::Context;
 use enclave_commands::{LightClientResult, UpdateClientInput, UpdateClientResult};
-use light_client::{LightClientKeeper, LightClientReader, LightClientSource};
+use light_client::{ClientKeeper, ClientReader, LightClientSource};
 use store::KVStore;
 
 pub fn update_client<'l, S: KVStore, L: LightClientSource<'l>>(

--- a/modules/ibc-client/src/client_def.rs
+++ b/modules/ibc-client/src/client_def.rs
@@ -13,7 +13,7 @@ use ibc::core::ics24_host::identifier::{ChannelId, ClientId, ConnectionId, PortI
 use ibc::core::ics24_host::path::ClientConsensusStatePath;
 use ibc_proto::ibc::core::commitment::v1::MerkleProof;
 use lcp_types::Height;
-use light_client::LightClientReader as ClientReader;
+use light_client::ClientReader;
 use tendermint_proto::Protobuf;
 use validation_context::{validation_predicate, ValidationContext};
 

--- a/modules/ibc-client/src/tests/client.rs
+++ b/modules/ibc-client/src/tests/client.rs
@@ -10,13 +10,12 @@ use commitments::{gen_state_id_from_any, UpdateClientCommitment};
 use ibc::core::ics02_client::client_state::ClientState as ICS02ClientState;
 use ibc::core::ics02_client::error::Error as ICS02Error;
 use ibc::core::ics03_connection::connection::ConnectionEnd;
-use ibc::core::ics03_connection::context::ConnectionReader;
 use ibc::core::ics04_channel::channel::ChannelEnd;
 use ibc::core::ics24_host::identifier::{ChannelId, ClientId, ConnectionId, PortId};
 use lcp_types::{Any, Height};
+use light_client::{ClientReader, LightClientError};
 use light_client::{CreateClientResult, StateVerificationResult, UpdateClientResult};
 use light_client::{LightClient, LightClientRegistry};
-use light_client::{LightClientError, LightClientReader};
 use log::*;
 use serde_json::Value;
 use std::boxed::Box;
@@ -34,7 +33,7 @@ pub struct LCPLightClient;
 impl LightClient for LCPLightClient {
     fn create_client(
         &self,
-        ctx: &dyn LightClientReader,
+        ctx: &dyn ClientReader,
         any_client_state: Any,
         any_consensus_state: Any,
     ) -> Result<CreateClientResult, LightClientError> {
@@ -70,7 +69,7 @@ impl LightClient for LCPLightClient {
 
     fn update_client(
         &self,
-        ctx: &dyn LightClientReader,
+        ctx: &dyn ClientReader,
         client_id: ClientId,
         any_header: Any,
     ) -> Result<UpdateClientResult, LightClientError> {
@@ -120,7 +119,7 @@ impl LightClient for LCPLightClient {
 
     fn verify_client(
         &self,
-        ctx: &dyn ConnectionReader,
+        ctx: &dyn ClientReader,
         client_id: ClientId,
         expected_client_state: Any,
         counterparty_prefix: Vec<u8>,
@@ -133,7 +132,7 @@ impl LightClient for LCPLightClient {
 
     fn verify_client_consensus(
         &self,
-        ctx: &dyn ConnectionReader,
+        ctx: &dyn ClientReader,
         client_id: ClientId,
         expected_client_consensus_state: Any,
         counterparty_prefix: Vec<u8>,
@@ -147,7 +146,7 @@ impl LightClient for LCPLightClient {
 
     fn verify_connection(
         &self,
-        ctx: &dyn ConnectionReader,
+        ctx: &dyn ClientReader,
         client_id: ClientId,
         expected_connection_state: ConnectionEnd,
         counterparty_prefix: Vec<u8>,
@@ -160,7 +159,7 @@ impl LightClient for LCPLightClient {
 
     fn verify_channel(
         &self,
-        ctx: &dyn ConnectionReader,
+        ctx: &dyn ClientReader,
         client_id: ClientId,
         expected_channel_state: ChannelEnd,
         counterparty_prefix: Vec<u8>,

--- a/modules/light-client/src/client.rs
+++ b/modules/light-client/src/client.rs
@@ -1,11 +1,10 @@
 #[cfg(feature = "sgx")]
 use crate::sgx_reexport_prelude::*;
-use crate::LightClientError;
+use crate::{context::ClientReader, LightClientError};
 use commitments::{StateCommitment, UpdateClientCommitment};
 use ibc::{
     core::{
-        ics02_client::{context::ClientReader, error::Error as ICS02Error},
-        ics03_connection::{connection::ConnectionEnd, context::ConnectionReader},
+        ics03_connection::connection::ConnectionEnd,
         ics04_channel::channel::ChannelEnd,
         ics24_host::identifier::{ChannelId, ClientId, ConnectionId, PortId},
     },
@@ -18,19 +17,19 @@ use std::vec::Vec;
 pub trait LightClient {
     fn create_client(
         &self,
-        ctx: &dyn LightClientReader,
+        ctx: &dyn ClientReader,
         any_client_state: Any,
         any_consensus_state: Any,
     ) -> Result<CreateClientResult, LightClientError>;
     fn update_client(
         &self,
-        ctx: &dyn LightClientReader,
+        ctx: &dyn ClientReader,
         client_id: ClientId,
         any_header: Any,
     ) -> Result<UpdateClientResult, LightClientError>;
     fn verify_client(
         &self,
-        ctx: &dyn ConnectionReader,
+        ctx: &dyn ClientReader,
         client_id: ClientId,
         expected_client_state: Any,
         counterparty_prefix: Vec<u8>,
@@ -40,7 +39,7 @@ pub trait LightClient {
     ) -> Result<StateVerificationResult, LightClientError>;
     fn verify_client_consensus(
         &self,
-        ctx: &dyn ConnectionReader,
+        ctx: &dyn ClientReader,
         client_id: ClientId,
         expected_client_consensus_state: Any,
         counterparty_prefix: Vec<u8>,
@@ -51,7 +50,7 @@ pub trait LightClient {
     ) -> Result<StateVerificationResult, LightClientError>;
     fn verify_connection(
         &self,
-        ctx: &dyn ConnectionReader,
+        ctx: &dyn ClientReader,
         client_id: ClientId,
         expected_connection_state: ConnectionEnd,
         counterparty_prefix: Vec<u8>,
@@ -61,7 +60,7 @@ pub trait LightClient {
     ) -> Result<StateVerificationResult, LightClientError>;
     fn verify_channel(
         &self,
-        ctx: &dyn ConnectionReader,
+        ctx: &dyn ClientReader,
         client_id: ClientId,
         expected_channel_state: ChannelEnd,
         counterparty_prefix: Vec<u8>,
@@ -96,62 +95,4 @@ pub struct UpdateClientResult {
 #[derive(Clone, Debug, PartialEq)]
 pub struct StateVerificationResult {
     pub state_commitment: StateCommitment,
-}
-
-pub trait LightClientReader {
-    fn client_type(&self, client_id: &ClientId) -> Result<String, ICS02Error>;
-    fn client_state(&self, client_id: &ClientId) -> Result<Any, ICS02Error>;
-    fn consensus_state(&self, client_id: &ClientId, height: Height) -> Result<Any, ICS02Error>;
-    fn host_height(&self) -> Height;
-    fn host_timestamp(&self) -> Timestamp;
-    fn as_client_reader(&self) -> &dyn ClientReader;
-}
-
-pub trait LightClientKeeper {
-    /// Called upon successful client creation
-    fn store_client_type(
-        &mut self,
-        client_id: ClientId,
-        client_type: String,
-    ) -> Result<(), ICS02Error>;
-
-    /// Called upon successful client creation and update
-    fn store_any_client_state(
-        &mut self,
-        client_id: ClientId,
-        client_state: Any,
-    ) -> Result<(), ICS02Error>;
-
-    /// Called upon successful client creation and update
-    fn store_any_consensus_state(
-        &mut self,
-        client_id: ClientId,
-        height: Height,
-        consensus_state: Any,
-    ) -> Result<(), ICS02Error>;
-
-    /// Called upon client creation.
-    /// Increases the counter which keeps track of how many clients have been created.
-    /// Should never fail.
-    fn increase_client_counter(&mut self);
-
-    /// Called upon successful client update.
-    /// Implementations are expected to use this to record the specified time as the time at which
-    /// this update (or header) was processed.
-    fn store_update_time(
-        &mut self,
-        client_id: ClientId,
-        height: Height,
-        timestamp: Timestamp,
-    ) -> Result<(), ICS02Error>;
-
-    /// Called upon successful client update.
-    /// Implementations are expected to use this to record the specified height as the height at
-    /// at which this update (or header) was processed.
-    fn store_update_height(
-        &mut self,
-        client_id: ClientId,
-        height: Height,
-        host_height: Height,
-    ) -> Result<(), ICS02Error>;
 }

--- a/modules/light-client/src/context.rs
+++ b/modules/light-client/src/context.rs
@@ -1,0 +1,67 @@
+use ibc::{
+    core::{
+        ics02_client::{context::ClientReader as IBCClientReader, error::Error as ICS02Error},
+        ics24_host::identifier::ClientId,
+    },
+    timestamp::Timestamp,
+};
+use lcp_types::{Any, Height};
+use std::string::String;
+
+pub trait ClientReader {
+    fn client_type(&self, client_id: &ClientId) -> Result<String, ICS02Error>;
+    fn client_state(&self, client_id: &ClientId) -> Result<Any, ICS02Error>;
+    fn consensus_state(&self, client_id: &ClientId, height: Height) -> Result<Any, ICS02Error>;
+    fn host_height(&self) -> Height;
+    fn host_timestamp(&self) -> Timestamp;
+    fn as_ibc_client_reader(&self) -> &dyn IBCClientReader;
+}
+
+pub trait ClientKeeper {
+    /// Called upon successful client creation
+    fn store_client_type(
+        &mut self,
+        client_id: ClientId,
+        client_type: String,
+    ) -> Result<(), ICS02Error>;
+
+    /// Called upon successful client creation and update
+    fn store_any_client_state(
+        &mut self,
+        client_id: ClientId,
+        client_state: Any,
+    ) -> Result<(), ICS02Error>;
+
+    /// Called upon successful client creation and update
+    fn store_any_consensus_state(
+        &mut self,
+        client_id: ClientId,
+        height: Height,
+        consensus_state: Any,
+    ) -> Result<(), ICS02Error>;
+
+    /// Called upon client creation.
+    /// Increases the counter which keeps track of how many clients have been created.
+    /// Should never fail.
+    fn increase_client_counter(&mut self);
+
+    /// Called upon successful client update.
+    /// Implementations are expected to use this to record the specified time as the time at which
+    /// this update (or header) was processed.
+    fn store_update_time(
+        &mut self,
+        client_id: ClientId,
+        height: Height,
+        timestamp: Timestamp,
+    ) -> Result<(), ICS02Error>;
+
+    /// Called upon successful client update.
+    /// Implementations are expected to use this to record the specified height as the height at
+    /// at which this update (or header) was processed.
+    fn store_update_height(
+        &mut self,
+        client_id: ClientId,
+        height: Height,
+        host_height: Height,
+    ) -> Result<(), ICS02Error>;
+}

--- a/modules/light-client/src/lib.rs
+++ b/modules/light-client/src/lib.rs
@@ -10,13 +10,12 @@ pub mod sgx_reexport_prelude {
     pub use thiserror_sgx as thiserror;
 }
 
-pub use client::{
-    CreateClientResult, LightClient, LightClientKeeper, LightClientReader, StateVerificationResult,
-    UpdateClientResult,
-};
+pub use client::{CreateClientResult, LightClient, StateVerificationResult, UpdateClientResult};
+pub use context::{ClientKeeper, ClientReader};
 pub use errors::{LightClientError, LightClientInstanceError, Result};
 pub use registry::{LightClientRegistry, LightClientSource};
 
 mod client;
+mod context;
 mod errors;
 mod registry;

--- a/modules/mock-lc/src/client.rs
+++ b/modules/mock-lc/src/client.rs
@@ -12,13 +12,13 @@ use ibc::core::ics02_client::client_type::ClientType;
 use ibc::core::ics02_client::error::Error as ICS02Error;
 use ibc::core::ics02_client::header::{AnyHeader, Header};
 use ibc::core::ics03_connection::connection::ConnectionEnd;
-use ibc::core::ics03_connection::context::ConnectionReader;
 use ibc::core::ics04_channel::channel::ChannelEnd;
 use ibc::core::ics24_host::identifier::{ChannelId, ClientId, ConnectionId, PortId};
 use lcp_types::{Any, Height};
-use light_client::{CreateClientResult, StateVerificationResult, UpdateClientResult};
-use light_client::{LightClient, LightClientRegistry};
-use light_client::{LightClientError, LightClientReader};
+use light_client::{
+    ClientReader, CreateClientResult, LightClient, LightClientError, LightClientRegistry,
+    StateVerificationResult, UpdateClientResult,
+};
 use serde_json::Value;
 use std::boxed::Box;
 use std::string::ToString;
@@ -31,7 +31,7 @@ pub struct MockLightClient;
 impl LightClient for MockLightClient {
     fn create_client(
         &self,
-        _: &dyn LightClientReader,
+        _: &dyn ClientReader,
         any_client_state: Any,
         any_consensus_state: Any,
     ) -> Result<CreateClientResult, LightClientError> {
@@ -87,11 +87,11 @@ impl LightClient for MockLightClient {
 
     fn update_client(
         &self,
-        ctx: &dyn LightClientReader,
+        ctx: &dyn ClientReader,
         client_id: ClientId,
         any_header: Any,
     ) -> Result<UpdateClientResult, LightClientError> {
-        let ctx = ctx.as_client_reader();
+        let ctx = ctx.as_ibc_client_reader();
         let header = match AnyHeader::try_from(any_header) {
             Ok(AnyHeader::Mock(header)) => AnyHeader::Mock(header),
             #[allow(unreachable_patterns)]
@@ -175,7 +175,7 @@ impl LightClient for MockLightClient {
 
     fn verify_client(
         &self,
-        ctx: &dyn ConnectionReader,
+        ctx: &dyn ClientReader,
         client_id: ClientId,
         expected_client_state: Any,
         counterparty_prefix: Vec<u8>,
@@ -188,7 +188,7 @@ impl LightClient for MockLightClient {
 
     fn verify_client_consensus(
         &self,
-        ctx: &dyn ConnectionReader,
+        ctx: &dyn ClientReader,
         client_id: ClientId,
         expected_client_consensus_state: Any,
         counterparty_prefix: Vec<u8>,
@@ -202,7 +202,7 @@ impl LightClient for MockLightClient {
 
     fn verify_connection(
         &self,
-        ctx: &dyn ConnectionReader,
+        ctx: &dyn ClientReader,
         client_id: ClientId,
         expected_connection_state: ConnectionEnd,
         counterparty_prefix: Vec<u8>,
@@ -215,7 +215,7 @@ impl LightClient for MockLightClient {
 
     fn verify_channel(
         &self,
-        ctx: &dyn ConnectionReader,
+        ctx: &dyn ClientReader,
         client_id: ClientId,
         expected_channel_state: ChannelEnd,
         counterparty_prefix: Vec<u8>,


### PR DESCRIPTION
This PR inculdes 
- rename the traits for context to Client{Reader,Keeper} respectively
- LightClient receives a trait object for ClientReader as context in the verification functions
- remove the impl of ConnectionReader for context
- fix lint errors

Signed-off-by: Jun Kimura <jun.kimura@datachain.jp>