### PR TITLE
make LightClientInstanceError convertible into LightClientError

### DIFF
--- a/modules/ibc-client/src/tests/client.rs
+++ b/modules/ibc-client/src/tests/client.rs
@@ -39,7 +39,7 @@ impl LightClient for LCPLightClient {
     ) -> Result<CreateClientResult, LightClientError> {
         let client_id = gen_client_id(&any_client_state, &any_consensus_state)?;
         let state_id = gen_state_id_from_any(&any_client_state, &any_consensus_state)
-            .map_err(|e| LightClientError::OtherError(e).into())?;
+            .map_err(LightClientError::OtherError)?;
         let client_state = ClientState::try_from(any_client_state.to_proto())
             .map_err(LightClientError::ICS02Error)?;
         let consensus_state = ConsensusState::try_from(any_consensus_state.to_proto())
@@ -104,7 +104,7 @@ impl LightClient for LCPLightClient {
         let (new_client_state, new_consensus_state) = LCPClient {}
             .check_header_and_update_state(ctx, client_id.clone(), client_state, header)
             .map_err(|e| {
-                Error::ICS02Error(ICS02Error::header_verification_failure(e.to_string())).into()
+                Error::ICS02Error(ICS02Error::header_verification_failure(e.to_string()))
             })?;
 
         Ok(UpdateClientResult {

--- a/modules/ibc-client/src/tests/errors.rs
+++ b/modules/ibc-client/src/tests/errors.rs
@@ -29,9 +29,3 @@ pub enum LCPLCError {
 }
 
 impl LightClientInstanceError for LCPLCError {}
-
-impl Into<LightClientError> for LCPLCError {
-    fn into(self) -> LightClientError {
-        LightClientError::InstanceError(Arc::new(Box::new(self)))
-    }
-}

--- a/modules/light-client/src/errors.rs
+++ b/modules/light-client/src/errors.rs
@@ -25,3 +25,9 @@ pub enum LightClientError {
 }
 
 pub trait LightClientInstanceError: Display + Debug {}
+
+impl<T: 'static + LightClientInstanceError> From<T> for LightClientError {
+    fn from(value: T) -> Self {
+        Self::InstanceError(Arc::new(Box::new(value)))
+    }
+}

--- a/modules/mock-lc/src/client.rs
+++ b/modules/mock-lc/src/client.rs
@@ -37,7 +37,7 @@ impl LightClient for MockLightClient {
     ) -> Result<CreateClientResult, LightClientError> {
         let client_id = gen_client_id(&any_client_state, &any_consensus_state)?;
         let state_id = gen_state_id_from_any(&any_client_state, &any_consensus_state)
-            .map_err(|e| Error::OtherError(e).into())?;
+            .map_err(|e| Error::OtherError(e))?;
         let client_state = match AnyClientState::try_from(any_client_state.clone()) {
             Ok(AnyClientState::Mock(client_state)) => AnyClientState::Mock(client_state),
             #[allow(unreachable_patterns)]
@@ -104,14 +104,14 @@ impl LightClient for MockLightClient {
         // Read client type from the host chain store. The client should already exist.
         let client_type = ctx
             .client_type(&client_id)
-            .map_err(|e| Error::ICS02Error(e).into())?;
+            .map_err(|e| Error::ICS02Error(e))?;
 
         let client_def = AnyClient::from_client_type(client_type);
 
         // Read client state from the host chain store.
         let client_state = ctx
             .client_state(&client_id)
-            .map_err(|e| Error::ICS02Error(e).into())?;
+            .map_err(|e| Error::ICS02Error(e))?;
 
         if client_state.is_frozen() {
             return Err(Error::ICS02Error(ICS02Error::client_frozen(client_id)).into());
@@ -130,7 +130,6 @@ impl LightClient for MockLightClient {
                         client_id.clone(),
                         latest_height,
                     ))
-                    .into()
                 })?;
 
         // Use client_state to validate the new header against the latest consensus_state.
@@ -139,13 +138,13 @@ impl LightClient for MockLightClient {
         let (new_client_state, new_consensus_state) = client_def
             .check_header_and_update_state(ctx, client_id.clone(), client_state.clone(), header)
             .map_err(|e| {
-                Error::ICS02Error(ICS02Error::header_verification_failure(e.to_string())).into()
+                Error::ICS02Error(ICS02Error::header_verification_failure(e.to_string()))
             })?;
 
-        let prev_state_id = gen_state_id(client_state, latest_consensus_state)
-            .map_err(|e| Error::OtherError(e).into())?;
+        let prev_state_id =
+            gen_state_id(client_state, latest_consensus_state).map_err(|e| Error::OtherError(e))?;
         let new_state_id = gen_state_id(new_client_state.clone(), new_consensus_state.clone())
-            .map_err(|e| Error::OtherError(e).into())?;
+            .map_err(|e| Error::OtherError(e))?;
         let header_timestamp_nanos = header_timestamp
             .into_datetime()
             .unwrap()

--- a/modules/mock-lc/src/client.rs
+++ b/modules/mock-lc/src/client.rs
@@ -37,7 +37,7 @@ impl LightClient for MockLightClient {
     ) -> Result<CreateClientResult, LightClientError> {
         let client_id = gen_client_id(&any_client_state, &any_consensus_state)?;
         let state_id = gen_state_id_from_any(&any_client_state, &any_consensus_state)
-            .map_err(|e| Error::OtherError(e))?;
+            .map_err(Error::OtherError)?;
         let client_state = match AnyClientState::try_from(any_client_state.clone()) {
             Ok(AnyClientState::Mock(client_state)) => AnyClientState::Mock(client_state),
             #[allow(unreachable_patterns)]
@@ -102,16 +102,12 @@ impl LightClient for MockLightClient {
         };
 
         // Read client type from the host chain store. The client should already exist.
-        let client_type = ctx
-            .client_type(&client_id)
-            .map_err(|e| Error::ICS02Error(e))?;
+        let client_type = ctx.client_type(&client_id).map_err(Error::ICS02Error)?;
 
         let client_def = AnyClient::from_client_type(client_type);
 
         // Read client state from the host chain store.
-        let client_state = ctx
-            .client_state(&client_id)
-            .map_err(|e| Error::ICS02Error(e))?;
+        let client_state = ctx.client_state(&client_id).map_err(Error::ICS02Error)?;
 
         if client_state.is_frozen() {
             return Err(Error::ICS02Error(ICS02Error::client_frozen(client_id)).into());
@@ -142,9 +138,9 @@ impl LightClient for MockLightClient {
             })?;
 
         let prev_state_id =
-            gen_state_id(client_state, latest_consensus_state).map_err(|e| Error::OtherError(e))?;
+            gen_state_id(client_state, latest_consensus_state).map_err(Error::OtherError)?;
         let new_state_id = gen_state_id(new_client_state.clone(), new_consensus_state.clone())
-            .map_err(|e| Error::OtherError(e))?;
+            .map_err(Error::OtherError)?;
         let header_timestamp_nanos = header_timestamp
             .into_datetime()
             .unwrap()

--- a/modules/mock-lc/src/errors.rs
+++ b/modules/mock-lc/src/errors.rs
@@ -29,9 +29,3 @@ pub enum MockLCError {
 }
 
 impl LightClientInstanceError for MockLCError {}
-
-impl Into<LightClientError> for MockLCError {
-    fn into(self) -> LightClientError {
-        LightClientError::InstanceError(Arc::new(Box::new(self)))
-    }
-}

--- a/modules/tendermint-lc/src/errors.rs
+++ b/modules/tendermint-lc/src/errors.rs
@@ -29,9 +29,3 @@ pub enum TendermintError {
 }
 
 impl LightClientInstanceError for TendermintError {}
-
-impl Into<LightClientError> for TendermintError {
-    fn into(self) -> LightClientError {
-        LightClientError::InstanceError(Arc::new(Box::new(self)))
-    }
-}


### PR DESCRIPTION
The error type conversion with `?` operator is conducted using not `Into` but `From`.
Therefore `impl From<OurErrorType> for LightClientError` can provide simpler codes than `impl Into<LightClientError> for OurErrorType`.

Signed-off-by: Masanori Yoshida <masanori.yoshida@datachain.jp>