### PR TITLE
Introduce host environment and configuable handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
  "clap",
  "color-eyre",
  "fs-err",
- "once_cell 1.13.0",
+ "once_cell 1.15.0",
  "regex 1.6.0",
  "secrecy",
  "semver",
@@ -609,7 +609,7 @@ dependencies = [
  "clap_derive",
  "clap_lex",
  "indexmap",
- "once_cell 1.13.0",
+ "once_cell 1.15.0",
  "strsim",
  "termcolor",
  "textwrap",
@@ -665,7 +665,7 @@ dependencies = [
  "color-spantrace",
  "eyre",
  "indenter",
- "once_cell 1.13.0",
+ "once_cell 1.15.0",
  "owo-colors",
  "tracing-error",
 ]
@@ -676,7 +676,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ba75b3d9449ecdccb27ecbc479fdc0b87fa2dd43d2f8298f9bf0e59aacc8dce"
 dependencies = [
- "once_cell 1.13.0",
+ "once_cell 1.15.0",
  "owo-colors",
  "tracing-core",
  "tracing-error",
@@ -719,7 +719,7 @@ checksum = "89eab4d20ce20cea182308bca13088fecea9c05f6776cf287205d41a0ed3c847"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell 1.13.0",
+ "once_cell 1.15.0",
  "terminal_size",
  "unicode-width",
  "winapi",
@@ -848,7 +848,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d82ee10ce34d7bc12c2122495e7593a9c41347ecdd64185af4ecf72cb1a7f83"
 dependencies = [
  "cfg-if 1.0.0",
- "once_cell 1.13.0",
+ "once_cell 1.15.0",
 ]
 
 [[package]]
@@ -1355,7 +1355,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
 dependencies = [
  "indenter",
- "once_cell 1.13.0",
+ "once_cell 1.15.0",
 ]
 
 [[package]]
@@ -1797,10 +1797,8 @@ dependencies = [
 name = "host"
 version = "0.1.0"
 dependencies = [
- "bincode 1.3.3",
  "log 0.4.17",
- "ocall-commands",
- "ocall-handler",
+ "once_cell 1.15.0",
  "sgx_types",
  "sgx_urts",
 ]
@@ -1814,6 +1812,13 @@ dependencies = [
  "sgx_tstd",
  "sgx_types",
  "thiserror 1.0.9",
+]
+
+[[package]]
+name = "host-environment"
+version = "0.1.0"
+dependencies = [
+ "store",
 ]
 
 [[package]]
@@ -2137,7 +2142,7 @@ dependencies = [
  "dashmap 5.3.4",
  "ibc",
  "moka",
- "once_cell 1.13.0",
+ "once_cell 1.15.0",
  "opentelemetry",
  "opentelemetry-prometheus",
  "prometheus",
@@ -2266,6 +2271,7 @@ dependencies = [
  "env_logger",
  "envconfig",
  "host",
+ "host-environment",
  "ibc",
  "ibc-integration-test",
  "ibc-proto",
@@ -2274,6 +2280,8 @@ dependencies = [
  "lcp-ibc-client",
  "lcp-types",
  "log 0.4.17",
+ "ocall-handler",
+ "once_cell 1.15.0",
  "prost-types",
  "relay-tendermint",
  "settings",
@@ -2358,7 +2366,10 @@ dependencies = [
  "env_logger",
  "hex",
  "host",
+ "host-environment",
  "log 0.4.17",
+ "ocall-handler",
+ "once_cell 1.15.0",
  "serde",
  "serde_json",
  "service",
@@ -2647,7 +2658,7 @@ dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils 0.8.10",
  "num_cpus",
- "once_cell 1.13.0",
+ "once_cell 1.15.0",
  "parking_lot",
  "quanta",
  "scheduled-thread-pool",
@@ -2797,6 +2808,9 @@ name = "ocall-handler"
 version = "0.1.0"
 dependencies = [
  "anyhow 1.0.58",
+ "bincode 1.3.3",
+ "host",
+ "host-environment",
  "log 0.4.17",
  "ocall-commands",
  "sgx_types",
@@ -2813,9 +2827,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
 name = "oneline-eyre"
@@ -3191,7 +3205,7 @@ dependencies = [
  "crossbeam-utils 0.8.10",
  "libc",
  "mach",
- "once_cell 1.13.0",
+ "once_cell 1.15.0",
  "raw-cpuid",
  "wasi 0.10.2+wasi-snapshot-preview1",
  "web-sys",
@@ -3485,7 +3499,7 @@ checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
 dependencies = [
  "cc",
  "libc",
- "once_cell 1.13.0",
+ "once_cell 1.15.0",
  "spin",
  "untrusted",
  "web-sys",
@@ -4447,7 +4461,7 @@ dependencies = [
  "futures",
  "k256",
  "num-traits",
- "once_cell 1.13.0",
+ "once_cell 1.15.0",
  "prost",
  "prost-types",
  "ripemd160",
@@ -4679,7 +4693,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
- "once_cell 1.13.0",
+ "once_cell 1.15.0",
 ]
 
 [[package]]
@@ -4716,7 +4730,7 @@ checksum = "62cc94d358b5a1e84a5cb9109f559aa3c4d634d2b1b4de3d0fa4adc7c78e2861"
 dependencies = [
  "anyhow 1.0.58",
  "hmac 0.12.1",
- "once_cell 1.13.0",
+ "once_cell 1.15.0",
  "pbkdf2",
  "rand 0.8.5",
  "rustc-hash",
@@ -4785,7 +4799,7 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
- "once_cell 1.13.0",
+ "once_cell 1.15.0",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -5015,7 +5029,7 @@ version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
 dependencies = [
- "once_cell 1.13.0",
+ "once_cell 1.15.0",
  "valuable",
 ]
 
@@ -5068,7 +5082,7 @@ checksum = "60db860322da191b40952ad9affe65ea23e7dd6a5c442c2c42865810c6ab8e6b"
 dependencies = [
  "ansi_term",
  "matchers",
- "once_cell 1.13.0",
+ "once_cell 1.15.0",
  "regex 1.6.0",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "app",
     "modules/host",
+    "modules/host-environment",
     "modules/types",
     "modules/ecall-handler",
     "modules/ocall-handler",

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -17,8 +17,11 @@ clap = { version = "3.2", features = ["derive"] }
 dirs = "4.0"
 serde = { version = "1.0", default-features = false, features = ["alloc"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
+once_cell = "1.15.0"
 
 host = { path = "../modules/host" }
+host-environment = { path = "../modules/host-environment" }
+ocall-handler = { path = "../modules/ocall-handler" }
 service = { path = "../modules/service" }
 enclave-api = { path = "../modules/enclave-api" }
 ecall-commands = { path = "../modules/ecall-commands" }

--- a/modules/host-environment/Cargo.toml
+++ b/modules/host-environment/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "host-environment"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+store = { path = "../store", default-features = false, features = ["std"] }

--- a/modules/host-environment/src/lib.rs
+++ b/modules/host-environment/src/lib.rs
@@ -1,0 +1,10 @@
+pub struct Environment {
+    // TODO env should keeps the store after refactoring host store
+// pub store: Arc<RwLock<dyn KVStore + Send + Sync>>,
+}
+
+impl Environment {
+    pub fn new() -> Self {
+        Self {}
+    }
+}

--- a/modules/host/Cargo.toml
+++ b/modules/host/Cargo.toml
@@ -7,7 +7,4 @@ edition = "2021"
 sgx_urts = { git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 sgx_types = { git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 log = "0.4.8"
-bincode = { version = "1.3" }
-
-ocall-handler = { path = "../../modules/ocall-handler" }
-ocall-commands = { path = "../../modules/ocall-commands" }
+once_cell = "1.15.0"

--- a/modules/ocall-handler/Cargo.toml
+++ b/modules/ocall-handler/Cargo.toml
@@ -8,4 +8,8 @@ sgx_types = { git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 log = { version = "0.4.8" }
 anyhow = { version = "1.0.56" }
 thiserror = { version = "1.0.30" }
+bincode = { version = "1.3" }
+
 ocall-commands = { path = "../ocall-commands", default-features = false }
+host-environment = { path = "../host-environment" }
+host = { path = "../host" }

--- a/modules/ocall-handler/src/handler.rs
+++ b/modules/ocall-handler/src/handler.rs
@@ -1,0 +1,65 @@
+use crate::dispatch;
+use host::ocalls::OCallHandler as HostOCallHandler;
+use host_environment::Environment;
+use log::*;
+use ocall_commands::{CommandResult, OCallCommand};
+use sgx_types::*;
+use std::slice;
+
+pub struct OCallHandler<'a> {
+    env: &'a Environment,
+}
+
+impl<'a> OCallHandler<'a> {
+    pub fn new(env: &'a Environment) -> Self {
+        Self { env }
+    }
+}
+
+impl<'a> HostOCallHandler for OCallHandler<'a> {
+    fn handle(
+        &self,
+        command: *const u8,
+        command_len: u32,
+        output_buf: *mut u8,
+        output_buf_maxlen: u32,
+        output_len: &mut u32,
+    ) -> sgx_status_t {
+        info!("Entering ocall_command_handler");
+
+        if let Err(e) = validate_const_ptr(command, command_len as usize) {
+            return e;
+        }
+
+        let cmd: OCallCommand =
+            bincode::deserialize(unsafe { slice::from_raw_parts(command, command_len as usize) })
+                .unwrap();
+
+        let (status, result) = match dispatch(self.env, cmd) {
+            Ok(result) => (sgx_status_t::SGX_SUCCESS, result),
+            Err(e) => (
+                sgx_status_t::SGX_ERROR_UNEXPECTED,
+                CommandResult::CommandError(format!("{:?}", e)),
+            ),
+        };
+        let res = bincode::serialize(&result).unwrap();
+        assert!(
+            output_buf_maxlen as usize >= res.len(),
+            "{} >= {}",
+            output_buf_maxlen as usize,
+            res.len()
+        );
+        unsafe { std::ptr::copy_nonoverlapping(res.as_ptr(), output_buf, res.len()) };
+        *output_len = res.len() as u32;
+
+        status
+    }
+}
+
+fn validate_const_ptr(ptr: *const u8, ptr_len: usize) -> SgxResult<()> {
+    if ptr.is_null() || ptr_len == 0 {
+        warn!("Tried to access an empty pointer - ptr.is_null()");
+        return Err(sgx_status_t::SGX_ERROR_UNEXPECTED);
+    }
+    Ok(())
+}

--- a/modules/ocall-handler/src/lib.rs
+++ b/modules/ocall-handler/src/lib.rs
@@ -1,5 +1,7 @@
+pub use handler::OCallHandler;
 pub use router::dispatch;
 
 mod errors;
+mod handler;
 mod remote_attestation;
 mod router;

--- a/modules/ocall-handler/src/router.rs
+++ b/modules/ocall-handler/src/router.rs
@@ -1,7 +1,8 @@
 use crate::{errors::Result, remote_attestation};
+use host_environment::Environment;
 use ocall_commands::{Command, CommandResult, OCallCommand};
 
-pub fn dispatch(command: OCallCommand) -> Result<CommandResult> {
+pub fn dispatch(_env: &Environment, command: OCallCommand) -> Result<CommandResult> {
     match command.cmd {
         Command::RemoteAttestation(cmd) => Ok(CommandResult::RemoteAttestation(
             remote_attestation::dispatch(cmd)?,

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -20,9 +20,12 @@ tokio = { version = "1.0" }
 log = "0.4.8"
 env_logger = "0.9.0"
 envconfig = "0.10.0"
+once_cell = "1.15.0"
 
 lcp-types = { path = "../../modules/types" }
 host = { path = "../../modules/host" }
+host-environment = { path = "../../modules/host-environment" }
+ocall-handler = { path = "../../modules/ocall-handler" }
 enclave-api = { path = "../../modules/enclave-api" }
 ecall-commands = { path = "../../modules/ecall-commands" }
 attestation-report = { path = "../../modules/attestation-report" }


### PR DESCRIPTION
ref #26 

The PR includes:
- introduces the host environement to keeps the store and environment vars for the host
- makes the ocall handler configurable with `once_cell`
- modify the handler to keep the environment to access the store

Signed-off-by: Jun Kimura <jun.kimura@datachain.jp>