### PR TITLE
Enable Service Threading

### DIFF
--- a/enclave/Enclave.config.xml
+++ b/enclave/Enclave.config.xml
@@ -4,8 +4,8 @@
   <ISVSVN>0</ISVSVN>
   <StackMaxSize>0x40000</StackMaxSize>
   <HeapMaxSize>0x100000</HeapMaxSize>
-  <TCSNum>1</TCSNum>
-  <TCSPolicy>1</TCSPolicy>
+  <TCSNum>2</TCSNum>
+  <TCSPolicy>0</TCSPolicy>
   <DisableDebug>0</DisableDebug>
   <MiscSelect>0</MiscSelect>
   <MiscMask>0xFFFFFFFF</MiscMask>


### PR DESCRIPTION
- Add `threads` option
  - This value is recommended to be less than or equal to `TCS_NUM` in Enclave config
- Modify TCSPolicy to 0
  - Currently `stdout` is wrapped with `SyncOnceCell` that uses `thread_local` in the rust-sgx-sdk. TCSPolicy must be set to 0 in order to print logs to stdout using tstd. However, I think we need to consider whether this should be applied to the production config only for the log. 