### PR TITLE
fix SetupHeader to adjust that an origin prover returns (nil, nil)

### DIFF
--- a/go/relay/prover.go
+++ b/go/relay/prover.go
@@ -153,6 +153,9 @@ func (pr *Prover) SetupHeader(dst core.LightClientIBCQueryierI, baseSrcHeader co
 	if err != nil {
 		return nil, err
 	}
+	if baseSrcHeader == nil {
+		return nil, nil
+	}
 	anyHeader, err := clienttypes.PackHeader(baseSrcHeader)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Signed-off-by: Koji Matsumiya <koji.matsumiya@datachain.jp>