### PR TITLE
app: use git tag as version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,9 +11,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: actions-rs/toolchain@v1
         with:
-            toolchain: nightly
+          toolchain: nightly
       - uses: datachainlab/rust-cache@allow_registry_src_caching
         with:
           workspaces: |
@@ -39,6 +41,8 @@ jobs:
       SGX_MODE: SW
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: actions-rs/toolchain@v1
         with:
             toolchain: nightly

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,15 +116,9 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56fc6cf8dc8c4158eed8649f9b8b0ea1518eb62b544fe9490d66fa0b349eafe9"
-
-[[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "android_system_properties"
@@ -639,12 +633,12 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.26"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
+checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
+ "num-integer",
  "num-traits",
  "serde",
  "winapi",
@@ -1659,6 +1653,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
 
 [[package]]
+name = "git2"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b989d6a7ca95a362cf2cfc5ad688b3a467be1f87e480b8dad07fee8c79b0044"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "libgit2-sys",
+ "log 0.4.17",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2551,6 +2560,7 @@ dependencies = [
  "ecall-commands",
  "enclave-api",
  "env_logger",
+ "git2",
  "hex",
  "host",
  "host-environment",
@@ -2620,6 +2630,20 @@ name = "libc"
 version = "0.2.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
+
+[[package]]
+name = "libgit2-sys"
+version = "0.15.2+1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a80df2e11fb4a61f4ba2ab42dbe7f74468da143f1a75c74e11dee7c813f694fa"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
 
 [[package]]
 name = "libloading"
@@ -2712,12 +2736,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "libssh2-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "libz-sys"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
 dependencies = [
  "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -3136,6 +3175,18 @@ name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.90"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "opentelemetry"

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -28,6 +28,9 @@ crypto = { path = "../modules/crypto" }
 store = { path = "../modules/store", features = ["rocksdbstore"] }
 keymanager = { path = "../modules/keymanager" }
 
+[build-dependencies]
+git2 = "0.17"
+
 [features]
 default = []
 sgx-sw = [

--- a/app/build.rs
+++ b/app/build.rs
@@ -1,9 +1,13 @@
+use git2::{DescribeOptions, Repository};
 use std::env;
 
-fn main() {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let sdk_dir = env::var("SGX_SDK").unwrap_or_else(|_| "/opt/sgxsdk".to_string());
     let sgx_mode = env::var("SGX_MODE").unwrap_or_else(|_| "HW".to_string());
-
+    let mut opts = DescribeOptions::new();
+    opts.describe_tags().show_commit_oid_as_fallback(true);
+    let version = Repository::discover(".")?.describe(&opts)?.format(None)?;
+    println!("cargo:rustc-env=LCP_VERSION={}", version);
     println!("cargo:rustc-link-search=native=./lib");
     println!("cargo:rustc-link-lib=static=Enclave_u");
     println!("cargo:rustc-link-search=native={}/lib64", sdk_dir);
@@ -24,4 +28,5 @@ fn main() {
             println!("cargo:rustc-link-lib=dylib=sgx_uae_service");
         }
     }
+    Ok(())
 }

--- a/app/src/cli.rs
+++ b/app/src/cli.rs
@@ -6,14 +6,14 @@ use clap::Parser;
 #[derive(Debug, Parser)]
 #[cfg_attr(feature = "sgx-sw", clap(
     name = env!("CARGO_PKG_NAME"),
-    version = concat!(env!("CARGO_PKG_VERSION"), "-sw"),
+    version = concat!(env!("LCP_VERSION"), "-sw"),
     author = env!("CARGO_PKG_AUTHORS"),
     about = env!("CARGO_PKG_DESCRIPTION"),
     arg_required_else_help = true,
 ))]
 #[cfg_attr(not(feature = "sgx-sw"), clap(
     name = env!("CARGO_PKG_NAME"),
-    version = env!("CARGO_PKG_VERSION"),
+    version = env!("LCP_VERSION"),
     author = env!("CARGO_PKG_AUTHORS"),
     about = env!("CARGO_PKG_DESCRIPTION"),
     arg_required_else_help = true,


### PR DESCRIPTION
```
$ ./bin/lcp
lcp v0.1.6-32-g8efd38f-sw

    LCP(Light Client Proxy) is a proxy middleware for light client verification

USAGE:
    lcp [OPTIONS] <SUBCOMMAND>

OPTIONS:
    -h, --help                     Print help information
        --home <HOME>              Path to LCP home directory
        --log_level <LOG_LEVEL>    Verbosity level of the logger
    -V, --version                  Print version information

SUBCOMMANDS:
    enclave        Enclave subcommands
    attestation    Attestation subcommands
    elc            ELC subcommands
    service        Service subcommands
    help           Print this message or the help of the given subcommand(s)

```