### PR TITLE
fix: ungraceful exit of init_client()

### DIFF
--- a/enclave-modules/ecall-handler/src/light_client/init_client.rs
+++ b/enclave-modules/ecall-handler/src/light_client/init_client.rs
@@ -17,7 +17,10 @@ pub fn init_client<R: LightClientResolver, S: KVStore, K: Signer>(
 
     let any_client_state: Any = input.any_client_state.into();
     let any_consensus_state: Any = input.any_consensus_state.into();
-    let lc = ctx.get_light_client(&any_client_state.type_url).unwrap();
+    let lc = match ctx.get_light_client(&any_client_state.type_url) {
+        Some(lc) => lc,
+        None => return Err(Error::invalid_argument(any_client_state.type_url.clone())),
+    };
     let ek = ctx.get_enclave_key();
     let res = lc.create_client(ctx, any_client_state.clone(), any_consensus_state.clone())?;
     let client_type = lc.client_type();


### PR DESCRIPTION
This fixes an ungraceful exit in the ecall handler of the lcp node, because an unchecked unwrap on a `None` value will panic and end the node server. During my tests this happened several times to me (supposedly due to a misconfiguration of the relayer setup - not sure yet). Maybe an ungraceful exit was the intention.... If that is the case, then I apologize. Humbly, Till.