### PR TITLE
LCP-5: Bump rustls to v0.23.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4223,7 +4223,7 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "rsa",
- "rustls 0.23.17",
+ "rustls 0.23.18",
  "sgx_types",
  "sha2 0.10.8",
  "store",
@@ -4505,9 +4505,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.17"
+version = "0.23.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f1a745511c54ba6d4465e8d5dfbd81b45791756de28d4981af70d6dca128f1e"
+checksum = "9c9cc1d47e243d655ace55ed38201c19ae02c148ae56412ab8750e8f0166ab7f"
 dependencies = [
  "aws-lc-rs",
  "log",


### PR DESCRIPTION
A new vulnerability was found in rustles v0.23.17. 
ref. https://rustsec.org/advisories/RUSTSEC-2024-0399