### PR TITLE
Update DCAP_VERSION to 1.23.100.0-jammy1

### DIFF
--- a/.github/scripts/install_sgx_sdk.sh
+++ b/.github/scripts/install_sgx_sdk.sh
@@ -7,13 +7,11 @@ if [ $# -eq 0 ]; then
 fi
 SDK_DIR_PREFIX=$1
 
-DCAP_VERSION=1.21.100.3-jammy1
+DCAP_VERSION=1.23.100.0-jammy1
 # create tmp dir
 TMP_DIR=$(mktemp -d)
 echo "Created temp dir: $TMP_DIR"
 cd $TMP_DIR
-# clone the repo
-git clone --recursive https://github.com/intel/SGXDataCenterAttestationPrimitives  -b dcap_1.21_reproducible --depth 1
 
 wget https://download.01.org/intel-sgx/sgx-dcap/1.21/linux/distro/ubuntu22.04-server/sgx_linux_x64_sdk_2.24.100.3.bin -O sgx_linux_x64_sdk.bin
 chmod a+x sgx_linux_x64_sdk.bin


### PR DESCRIPTION
As far as I can tell from https://download.01.org/intel-sgx/sgx_repo/ubuntu/dists/jammy/main/binary-amd64/Packages, 1.21.100.3-jammy1 is no longer available.
This PR updates `DCAP_VERSION` to 1.23.100.0-jammy1, which is the version currently available in the repository.

Without this change, the CI fails as follows:

```
Reading package lists...
+ apt-get install -y libsgx-dcap-ql=1.21.100.3-jammy1 libsgx-dcap-ql-dev=1.21.100.3-jammy1
Reading package lists...
Building dependency tree...
Reading state information...
Package libsgx-dcap-ql is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

Package libsgx-dcap-ql-dev is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Version '1.21.100.3-jammy1' for 'libsgx-dcap-ql' was not found
E: Version '1.21.100.3-jammy1' for 'libsgx-dcap-ql-dev' was not found
```

