### PR TITLE
Improve sgx debugger support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,31 +1,30 @@
 ######## LCP Build Settings ########
-ZK_PROVER_CUDA ?= 0
+ZK_PROVER_CUDA  ?= 0
 APP_CARGO_FLAGS ?=
 
 ######## SGX SDK Settings ########
-SGX_SDK ?= /opt/sgxsdk
-SGX_MODE ?= HW
-SGX_DEBUG ?= 0
+SGX_SDK            ?= /opt/sgxsdk
+SGX_MODE           ?= HW
+SGX_DEBUG          ?= 0
 SGX_ENCLAVE_CONFIG ?= "enclave/Enclave.config.xml"
-SGX_SIGN_KEY ?= "enclave/Enclave_private.pem"
+SGX_SIGN_KEY       ?= "enclave/Enclave_private.pem"
 
-SGX_COMMON_CFLAGS := -m64
-SGX_LIBRARY_PATH := $(SGX_SDK)/lib64
+SGX_COMMON_CFLAGS  := -m64
+SGX_LIBRARY_PATH   := $(SGX_SDK)/lib64
 SGX_ENCLAVE_SIGNER := $(SGX_SDK)/bin/x64/sgx_sign
-SGX_EDGER8R := $(SGX_SDK)/bin/x64/sgx_edger8r
+SGX_EDGER8R        := $(SGX_SDK)/bin/x64/sgx_edger8r
 
 include buildenv.mk
 
 ifeq ($(SGX_DEBUG), 1)
-	# we build with cargo --release, even in SGX DEBUG mode
 	SGX_COMMON_CFLAGS += -O0 -g -ggdb
-	# cargo sets this automatically, cannot use 'debug'
-	OUTPUT_PATH := release
-	CARGO_TARGET := --release
+	# debug build
+	CARGO_TARGET      :=
+	OUTPUT_PATH       := debug
 else
 	SGX_COMMON_CFLAGS += -O2
-	OUTPUT_PATH := release
-	CARGO_TARGET := --release
+	CARGO_TARGET      := --release
+	OUTPUT_PATH       := release
 endif
 
 SGX_COMMON_CFLAGS += -fstack-protector

--- a/enclave/Enclave.lds
+++ b/enclave/Enclave.lds
@@ -4,6 +4,8 @@ enclave.so
         g_global_data_sim;
         g_global_data;
         enclave_entry;
+        g_peak_heap_used;
+        g_peak_rsrv_mem_committed;
     local:
         *;
 };


### PR DESCRIPTION
## What

Modify the enclave's linker script to export `g_peak_heap_used` and `g_peak_rsrv_mem_committed`. We can use it in debug build to obtain the amount of heap memory used by SGX emmt.

## Example

```
$ make SGX_DEBUG=1 all
Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.80s
LINK =>  enclave/enclave.so
mkdir -p bin
<!-- Please refer to User's Guide for the explanation of each field -->
<EnclaveConfiguration>
    <ProdID>0</ProdID>
    <ISVSVN>0</ISVSVN>
    <StackMaxSize>0x40000</StackMaxSize>
    <HeapMaxSize>0x100000</HeapMaxSize>
    <TCSNum>2</TCSNum>
    <TCSPolicy>0</TCSPolicy>
    <DisableDebug>0</DisableDebug>
    <MiscSelect>0</MiscSelect>
    <MiscMask>0xFFFFFFFF</MiscMask>
</EnclaveConfiguration>
tcs_num 2, tcs_max_num 2, tcs_min_pool 1
INFO: Enclave configuration 'MiscSelect' and 'MiscSelectMask' will prevent enclave from using dynamic features. To use the dynamic features on SGX2 platform, suggest to set MiscMask[0]=0 and MiscSelect[0]=1.
The required memory is 8118272B.
The required memory is 0x7be000, 7928 KB.
handle_compatible_metadata: Overwrite with metadata version 0x100000005
Succeed.
SIGN =>  bin/enclave.signed.so

$ sgx-gdb -ex="enable sgx_emmt" -ex=r -ex=quit --args ./bin/lcp enclave generate-key --enclave=./bin/enclave.signed.so --target_qe=qe3sim
GNU gdb (Ubuntu 12.1-0ubuntu1~22.04.2) 12.1
Copyright (C) 2022 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "x86_64-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Source directories searched: /opt/intel/sgxsdk/lib64/gdb-sgx-plugin:$cdir:$cwd
Setting environment variable "LD_PRELOAD" to null value.
Reading symbols from ./bin/lcp...
Loading libc++ pretty-printers.
warning: Missing auto-load script at offset 0 in section .debug_gdb_scripts
of file /home/jun/repos/github.com/datachainlab/lcp/bin/lcp.
Use `info auto-load python-scripts [REGEXP]' to list them.
Starting program: /home/jun/repos/github.com/datachainlab/lcp/bin/lcp enclave generate-key --enclave=./bin/enclave.signed.so --target_qe=qe3sim
detect urts is loaded, initializing
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
detect urts is loaded, initializing
[New Thread 0x7ffff65ff640 (LWP 839675)]
[New Thread 0x7ffff5dfe640 (LWP 839676)]
[New Thread 0x7ffff55fd640 (LWP 839677)]
[New Thread 0x7ffff4dfc640 (LWP 839678)]
[Thread 0x7ffff55fd640 (LWP 839677) exited]
[Thread 0x7ffff4dfc640 (LWP 839678) exited]
[New Thread 0x7fffe7fff640 (LWP 839679)]
[Thread 0x7fffe7fff640 (LWP 839679) exited]
[New Thread 0x7fffe77fe640 (LWP 839680)]
[Thread 0x7fffe77fe640 (LWP 839680) exited]
[New Thread 0x7fffe6ffd640 (LWP 839681)]
[Thread 0x7fffe6ffd640 (LWP 839681) exited]
[New Thread 0x7fffe67fc640 (LWP 839682)]
[New Thread 0x7fffe5ffb640 (LWP 839683)]
[Thread 0x7fffe67fc640 (LWP 839682) exited]
[Thread 0x7fffe5ffb640 (LWP 839683) exited]
[New Thread 0x7fffe57fa640 (LWP 839684)]
[Thread 0x7fffe57fa640 (LWP 839684) exited]
[New Thread 0x7fffe4ff9640 (LWP 839685)]
[Thread 0x7fffe4ff9640 (LWP 839685) exited]
[New Thread 0x7fffe47f8640 (LWP 839686)]
[Thread 0x7fffe47f8640 (LWP 839686) exited]
[New Thread 0x7fffe3ff7640 (LWP 839687)]
[Thread 0x7fffe3ff7640 (LWP 839687) exited]
[New Thread 0x7fffe37f6640 (LWP 839688)]
[Thread 0x7fffe37f6640 (LWP 839688) exited]
[New Thread 0x7fffe2ff5640 (LWP 839689)]
[Thread 0x7fffe2ff5640 (LWP 839689) exited]
[New Thread 0x7fffe27f4640 (LWP 839690)]
[Thread 0x7fffe27f4640 (LWP 839690) exited]
[New Thread 0x7fffe1ff3640 (LWP 839691)]
[Thread 0x7fffe1ff3640 (LWP 839691) exited]
[New Thread 0x7fffe1ff3640 (LWP 839692)]
[Thread 0x7fffe1ff3640 (LWP 839692) exited]
[New Thread 0x7fffe27f4640 (LWP 839693)]
[Thread 0x7fffe27f4640 (LWP 839693) exited]
[New Thread 0x7fffe2ff5640 (LWP 839694)]
[Thread 0x7fffe2ff5640 (LWP 839694) exited]
[New Thread 0x7fffe37f6640 (LWP 839695)]
[Thread 0x7fffe37f6640 (LWP 839695) exited]
[New Thread 0x7ffff55fd640 (LWP 839696)]
[New Thread 0x7ffff4dfc640 (LWP 839697)]
[Thread 0x7ffff55fd640 (LWP 839696) exited]
[Thread 0x7ffff4dfc640 (LWP 839697) exited]
[New Thread 0x7fffe7fff640 (LWP 839698)]
[Thread 0x7fffe7fff640 (LWP 839698) exited]
[New Thread 0x7fffe77fe640 (LWP 839699)]
[Thread 0x7fffe77fe640 (LWP 839699) exited]
[New Thread 0x7fffe6ffd640 (LWP 839700)]
[Thread 0x7fffe6ffd640 (LWP 839700) exited]
[New Thread 0x7fffe67fc640 (LWP 839701)]
[Thread 0x7fffe67fc640 (LWP 839701) exited]
[New Thread 0x7fffe5ffb640 (LWP 839702)]
[Thread 0x7fffe5ffb640 (LWP 839702) exited]
[New Thread 0x7fffe57fa640 (LWP 839703)]
[Thread 0x7fffe57fa640 (LWP 839703) exited]
[New Thread 0x7fffe4ff9640 (LWP 839704)]
[New Thread 0x7fffe47f8640 (LWP 839705)]
[Thread 0x7fffe4ff9640 (LWP 839704) exited]
[Thread 0x7fffe47f8640 (LWP 839705) exited]
[New Thread 0x7fffe3ff7640 (LWP 839706)]
[Thread 0x7fffe3ff7640 (LWP 839706) exited]
add-symbol-file '/home/jun/repos/github.com/datachainlab/lcp/bin/enclave.signed.so' 0x7ffff4646040 -s .interp 0x7ffff45fe2a8  -s .note.gnu.build-id 0x7ffff45fe2c4  -s .gnu.hash 0x7ffff45fe2e8  -s .dynsym 0x7ffff45fe328  -s .dynstr 0x7ffff45fe3e8  -s .gnu.version 0x7ffff45fe45e  -s .gnu.version_d 0x7ffff45fe470  -s .rela.dyn 0x7ffff45fe4a8  -s .plt 0x7ffff4646000  -s .plt.got 0x7ffff4646010  -s .nipx 0x7ffff4a350a0  -s .rodata 0x7ffff4a36000  -s .eh_frame_hdr 0x7ffff4b79f80  -s .eh_frame 0x7ffff4b92228  -s .gcc_except_table 0x7ffff4be505c  -s .init_array 0x7ffff4bf9c88  -s .fini_array 0x7ffff4bf9c90  -s .data.rel.ro 0x7ffff4bf9ce0  -s .dynamic 0x7ffff4c1bad0  -s .got 0x7ffff4c1bc60  -s .data 0x7ffff4c27000  -s .nipd 0x7ffff4c29708  -s .niprod 0x7ffff4c29740  -s .bss 0x7ffff4c2a080
0xfe44d3957bac8a82a93fb3bccb3e036c4c5b635d
Enclave: "/home/jun/repos/github.com/datachainlab/lcp/bin/enclave.signed.so"
  [Peak stack used]: 49 KB
  [Peak heap used]:  68 KB
  [Peak reserved memory used]:  0 KB
remove-symbol-file -a 140737293606976
[Thread 0x7ffff5dfe640 (LWP 839676) exited]
[Thread 0x7ffff65ff640 (LWP 839675) exited]
[Inferior 1 (process 839666) exited normally]
```