### PR TITLE
Validate enclave concurrency against TCS capacity

### DIFF
--- a/app/src/commands/service.rs
+++ b/app/src/commands/service.rs
@@ -1,6 +1,6 @@
 use crate::enclave::EnclaveLoader;
 use crate::opts::{EnclaveOpts, Opts};
-use anyhow::Result;
+use anyhow::{bail, Context, Result};
 use clap::Parser;
 use enclave_api::{Enclave, EnclaveInfo, EnclaveProtoAPI, SpeculativeEnclaveCommandAPI};
 use host::store::transaction::{CommitStore, TxAccessor};
@@ -75,6 +75,10 @@ impl ServiceCmd {
                     enclave_loader.load(opts, cmd.enclave.path.as_ref(), cmd.enclave.is_debug())?;
                 let metadata = enclave.metadata()?;
                 let mrenclave = metadata.mrenclave().to_hex_string();
+                let tcs_num = metadata
+                    .tcs_num()
+                    .context("failed to derive TCSNum from enclave metadata")?;
+                validate_enclave_parallelism(enclave_parallelism, tcs_num)?;
                 let mut rb = Builder::new_multi_thread();
                 let rb = if let Some(threads) = cmd.threads {
                     rb.worker_threads(threads)
@@ -90,6 +94,13 @@ impl ServiceCmd {
                         enclave_parallelism
                     );
                 }
+                if speculative_concurrency_limit > tcs_num {
+                    warn!(
+                        "max-speculative-concurrency ({}) is greater than enclave TCSNum ({}); excess speculative requests will wait for an EcallPool slot",
+                        speculative_concurrency_limit,
+                        tcs_num
+                    );
+                }
                 let srv = ElcService::new(
                     opts.get_home(),
                     enclave,
@@ -98,12 +109,41 @@ impl ServiceCmd {
                 );
 
                 info!(
-                    "start service: addr={addr} mrenclave={mrenclave} speculative_concurrency_limit={} enclave_parallelism={}",
+                    "start service: addr={addr} mrenclave={mrenclave} tcs_num={} tcs_policy={} speculative_concurrency_limit={} enclave_parallelism={}",
+                    tcs_num,
+                    metadata.tcs_policy(),
                     speculative_concurrency_limit,
                     enclave_parallelism
                 );
                 rt.block_on(async { run_service(srv, addr).await })
             }
         }
+    }
+}
+
+fn validate_enclave_parallelism(enclave_parallelism: usize, tcs_num: usize) -> Result<()> {
+    if enclave_parallelism > tcs_num {
+        bail!(
+            "max-enclave-concurrency ({}) exceeds enclave TCSNum ({}); reduce --max-enclave-concurrency or rebuild the enclave with a larger TCSNum",
+            enclave_parallelism,
+            tcs_num
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_enclave_parallelism;
+
+    #[test]
+    fn enclave_parallelism_may_equal_tcs_num() {
+        validate_enclave_parallelism(8, 8).unwrap();
+    }
+
+    #[test]
+    fn enclave_parallelism_cannot_exceed_tcs_num() {
+        let err = validate_enclave_parallelism(9, 8).unwrap_err();
+        assert!(err.to_string().contains("exceeds enclave TCSNum"));
     }
 }

--- a/modules/types/src/sgx.rs
+++ b/modules/types/src/sgx.rs
@@ -1,7 +1,14 @@
 use crate::{prelude::*, TypeError};
 use core::fmt::Display;
+use core::mem;
 use core::ops::Deref;
-use sgx_types::{metadata::metadata_t, sgx_measurement_t, SGX_HASH_SIZE};
+use sgx_types::{
+    metadata::{
+        dir_index_t, metadata_t, GROUP_FLAG, LAYOUT_ID_TCS_DYN, PAGE_ATTR_EADD, PAGE_ATTR_POST_ADD,
+        SI_FLAGS_TCS, TCS_POLICY_BIND, TCS_POLICY_UNBIND,
+    },
+    sgx_measurement_t, SGX_HASH_SIZE,
+};
 
 /// MRENCLAVE is a measurement of the enclave
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -88,5 +95,192 @@ impl EnclaveMetadata {
     /// Get the MRENCLAVE of the enclave from the metadata
     pub fn mrenclave(&self) -> Mrenclave {
         self.enclave_css.body.enclave_hash.m.into()
+    }
+
+    /// Get the enclave TCS policy from the metadata.
+    pub fn tcs_policy(&self) -> u32 {
+        self.tcs_policy
+    }
+
+    /// Returns true when the enclave metadata declares `TCSPolicy=BIND`.
+    pub fn tcs_policy_is_bind(&self) -> bool {
+        self.tcs_policy() == TCS_POLICY_BIND
+    }
+
+    /// Returns true when the enclave metadata declares `TCSPolicy=UNBIND`.
+    pub fn tcs_policy_is_unbind(&self) -> bool {
+        self.tcs_policy() == TCS_POLICY_UNBIND
+    }
+
+    /// Derive the configured TCS count from the enclave metadata layout table.
+    ///
+    /// `sgx_get_metadata` does not expose the original `Enclave.config.xml`
+    /// `<TCSNum>` directly. The signed metadata does contain the final layout
+    /// table, so this method mirrors the SGX runtime's TCS counting logic and
+    /// returns the number of TCS entries available to the enclave.
+    pub fn tcs_num(&self) -> Option<usize> {
+        let layout_dir = self.dirs[dir_index_t::DIR_LAYOUT as usize];
+        let offset = layout_dir.offset as usize;
+        let size = layout_dir.size as usize;
+        let metadata = unsafe {
+            core::slice::from_raw_parts(
+                (&self.0 as *const metadata_t).cast::<u8>(),
+                mem::size_of::<metadata_t>(),
+            )
+        };
+        let end = offset.checked_add(size)?;
+        if size == 0 || end > metadata.len() {
+            return None;
+        }
+
+        let layout = &metadata[offset..end];
+        let entry_count = layout.len() / LAYOUT_ENTRY_SIZE;
+        if entry_count == 0 {
+            return None;
+        }
+
+        let count = count_tcs_entries(layout, 0, entry_count);
+        (count > 0).then_some(count)
+    }
+}
+
+const LAYOUT_ENTRY_SIZE: usize = 32;
+
+fn count_tcs_entries(layout: &[u8], start: usize, end: usize) -> usize {
+    let mut count = 0usize;
+    for index in start..end {
+        let offset = index * LAYOUT_ENTRY_SIZE;
+        let Some(id) = read_u16(layout, offset) else {
+            break;
+        };
+        let id = id as u32;
+
+        if (id & GROUP_FLAG) != 0 {
+            let Some(entry_count) = read_u16(layout, offset + 2).map(usize::from) else {
+                continue;
+            };
+            let Some(load_times) = read_u32(layout, offset + 4).map(|v| v as usize) else {
+                continue;
+            };
+            let preceding_entries = index - start;
+            if entry_count == 0 || entry_count > preceding_entries {
+                continue;
+            }
+            let group_start = index - entry_count;
+            let group_count = count_tcs_entries(layout, group_start, index);
+            count = count.saturating_add(group_count.saturating_mul(load_times));
+            continue;
+        }
+
+        let Some(attributes) = read_u16(layout, offset + 2) else {
+            continue;
+        };
+        if (attributes & PAGE_ATTR_EADD) != 0 {
+            let Some(content_offset) = read_u32(layout, offset + 20) else {
+                continue;
+            };
+            let Some(si_flags) = read_u64(layout, offset + 24) else {
+                continue;
+            };
+            if content_offset != 0 && si_flags == SI_FLAGS_TCS {
+                count = count.saturating_add(1);
+                continue;
+            }
+        }
+        if (attributes & PAGE_ATTR_POST_ADD) != 0 && id == LAYOUT_ID_TCS_DYN {
+            count = count.saturating_add(1);
+        }
+    }
+    count
+}
+
+fn read_u16(input: &[u8], offset: usize) -> Option<u16> {
+    let bytes = input.get(offset..offset.checked_add(2)?)?;
+    Some(u16::from_le_bytes(bytes.try_into().ok()?))
+}
+
+fn read_u32(input: &[u8], offset: usize) -> Option<u32> {
+    let bytes = input.get(offset..offset.checked_add(4)?)?;
+    Some(u32::from_le_bytes(bytes.try_into().ok()?))
+}
+
+fn read_u64(input: &[u8], offset: usize) -> Option<u64> {
+    let bytes = input.get(offset..offset.checked_add(8)?)?;
+    Some(u64::from_le_bytes(bytes.try_into().ok()?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::mem::MaybeUninit;
+    use sgx_types::metadata::{LAYOUT_ID_TCS, LAYOUT_ID_THREAD_GROUP};
+
+    fn empty_metadata() -> metadata_t {
+        unsafe { MaybeUninit::zeroed().assume_init() }
+    }
+
+    fn metadata_data_offset() -> usize {
+        let metadata = MaybeUninit::<metadata_t>::uninit();
+        let base = metadata.as_ptr() as usize;
+        let data = unsafe { core::ptr::addr_of!((*metadata.as_ptr()).data) as usize };
+        data - base
+    }
+
+    fn write_u16(output: &mut [u8], offset: usize, value: u16) {
+        output[offset..offset + 2].copy_from_slice(&value.to_le_bytes());
+    }
+
+    fn write_u32(output: &mut [u8], offset: usize, value: u32) {
+        output[offset..offset + 4].copy_from_slice(&value.to_le_bytes());
+    }
+
+    fn write_u64(output: &mut [u8], offset: usize, value: u64) {
+        output[offset..offset + 8].copy_from_slice(&value.to_le_bytes());
+    }
+
+    fn write_tcs_entry(output: &mut [u8], index: usize) {
+        let offset = index * LAYOUT_ENTRY_SIZE;
+        write_u16(output, offset, LAYOUT_ID_TCS as u16);
+        write_u16(output, offset + 2, PAGE_ATTR_EADD as u16);
+        write_u32(output, offset + 20, 1);
+        write_u64(output, offset + 24, SI_FLAGS_TCS);
+    }
+
+    fn write_thread_group(output: &mut [u8], index: usize, entry_count: u16, load_times: u32) {
+        let offset = index * LAYOUT_ENTRY_SIZE;
+        write_u16(output, offset, LAYOUT_ID_THREAD_GROUP as u16);
+        write_u16(output, offset + 2, entry_count);
+        write_u32(output, offset + 4, load_times);
+    }
+
+    fn metadata_with_layout(layout: &[u8]) -> EnclaveMetadata {
+        let mut metadata = empty_metadata();
+        metadata.dirs[dir_index_t::DIR_LAYOUT as usize].offset = metadata_data_offset() as u32;
+        metadata.dirs[dir_index_t::DIR_LAYOUT as usize].size = layout.len() as u32;
+        metadata.data[..layout.len()].copy_from_slice(layout);
+        metadata.into()
+    }
+
+    #[test]
+    fn tcs_num_counts_tcs_layout_entries() {
+        let mut layout = [0u8; LAYOUT_ENTRY_SIZE * 2];
+        write_tcs_entry(&mut layout, 0);
+        write_tcs_entry(&mut layout, 1);
+
+        assert_eq!(metadata_with_layout(&layout).tcs_num(), Some(2));
+    }
+
+    #[test]
+    fn tcs_num_counts_group_repetitions_like_sgx_runtime() {
+        let mut layout = [0u8; LAYOUT_ENTRY_SIZE * 2];
+        write_tcs_entry(&mut layout, 0);
+        write_thread_group(&mut layout, 1, 1, 3);
+
+        assert_eq!(metadata_with_layout(&layout).tcs_num(), Some(4));
+    }
+
+    #[test]
+    fn tcs_num_returns_none_when_layout_is_absent() {
+        assert_eq!(EnclaveMetadata::from(empty_metadata()).tcs_num(), None);
     }
 }


### PR DESCRIPTION
## Summary
- derive the enclave TCS capacity from signed SGX metadata
- fail service startup when the dedicated ECALL pool size exceeds that TCS capacity
- log the detected TCS capacity and warn when speculative concurrency exceeds it

## Verification
- `cargo test -p lcp-types tcs_num -- --nocapture`
- `cargo test -p lcp enclave_parallelism -- --nocapture`
- `cargo check -p lcp --bin lcp`
